### PR TITLE
fork of write_metadata fixes #6; #8

### DIFF
--- a/main.inc.php
+++ b/main.inc.php
@@ -4,7 +4,7 @@ Plugin Name: Write Metadata
 Description: Write Piwigo photo properties (title, description, author, tags) into IPTC fields
 Author: plg
 Plugin URI: http://piwigo.org/ext/extension_view.php?eid=769
-Version: 2.8.a
+Version: auto
 */
 
 // +-----------------------------------------------------------------------+

--- a/main.inc.php
+++ b/main.inc.php
@@ -136,6 +136,8 @@ SELECT
   $tags = explode(",", $row['tags']);
 
   $command = isset($conf['exiftool_path']) ? $conf['exiftool_path'] : 'exiftool';
+  $command.= ' -charset iptc=UTF8';
+  // UTF8 should be the default, but obviously it isn't (libimage-exiftool-perl Version: 9.46-1; Ubuntu 14.04.5)
 
   if (strlen($name) > 0)
   {
@@ -174,7 +176,6 @@ SELECT
   foreach ($tags as $singletag) {
     $command.= ' -IPTC:Keywords="'.wm_cutString($singletag, 64).'"';
   }
-
 
   $command.= ' "'.$row['path'].'"';
   // echo $command;

--- a/main.inc.php
+++ b/main.inc.php
@@ -3,8 +3,8 @@
 Plugin Name: Write Metadata
 Description: Write Piwigo photo properties (title, description, author, tags) into IPTC fields
 Author: plg
-Plugin URI: http://piwigo.org/ext/extension_view.php?eid=
-Version: auto
+Plugin URI: http://piwigo.org/ext/extension_view.php?eid=769
+Version: 2.8.a
 */
 
 // +-----------------------------------------------------------------------+
@@ -54,17 +54,10 @@ function wm_picture_write_metadata()
   if (isset($page['page']) and 'photo' == $page['page'] and isset($_GET['write_metadata']))
   {
     check_input_parameter('image_id', $_GET, false, PATTERN_ID);
-    list($rc, $output) = wm_write_metadata($_GET['image_id']);
+    wm_write_metadata($_GET['image_id']);
 
-    if (count($output) == 0)
-    {
-      $_SESSION['page_infos'][] = l10n('Metadata written into file');
-      redirect(get_root_url().'admin.php?page=photo-'.$_GET['image_id'].'-properties');
-    }
-    else
-    {
-      $page['errors'] = array_merge($page['errors'], $output);
-    }
+    $_SESSION['page_infos'][] = l10n('Metadata written into file');
+    redirect(get_root_url().'admin.php?page=photo-'.$_GET['image_id'].'-properties');
   }
 }
 
@@ -143,7 +136,6 @@ SELECT
   $tags = wm_prepare_string($row['tags'], 64);
 
   $command = isset($conf['exiftool_path']) ? $conf['exiftool_path'] : 'exiftool';
-  $command.= ' -q';
 
   if (strlen($name) > 0)
   {
@@ -185,14 +177,13 @@ SELECT
   }
 
   $command.= ' "'.$row['path'].'"';
-  $command.= ' 2>&1';
   // echo $command;
 
-  $exec_return = exec($command, $output, $rc);
+  $exec_return = exec($command, $output);
   // echo '$exec_return = '.$exec_return.'<br>';
   // echo '<pre>'; print_r($output); echo '</pre>';
 
-  return array($rc, $output);
+  return true;
 }
 
 function wm_prepare_string($string, $maxLen)

--- a/main.inc.php
+++ b/main.inc.php
@@ -133,7 +133,7 @@ SELECT
   $name = wm_prepare_string($row['name'], 256);
   $description = wm_prepare_string($row['comment'], 2000);
   $author = wm_prepare_string($row['author'], 32);
-  $tags = wm_prepare_string($row['tags'], 64);
+  $tags = explode(",", $row['tags']);
 
   $command = isset($conf['exiftool_path']) ? $conf['exiftool_path'] : 'exiftool';
 
@@ -169,12 +169,12 @@ SELECT
 
     $command.= ' -IPTC:'.$iptc_field.'="'.$author.'"';
   }
-  
-  if (strlen($tags) > 0)
-  {
-    # 2#025 in iptcparse($imginfo['APP13'])
-    $command.= ' -IPTC:Keywords="'.$tags.'"';
+
+  # 2#025 in iptcparse($imginfo['APP13'])
+  foreach ($tags as $singletag) {
+    $command.= ' -IPTC:Keywords="'.wm_cutString($singletag, 64).'"';
   }
+
 
   $command.= ' "'.$row['path'].'"';
   // echo $command;


### PR DESCRIPTION
Dear Pierrick,
we commited a fork of plegall/Piwigo-write_metadata, which fixes #6 (UTF-8 charset) and #8 (keywords 'glued' together as one single keyword entry).
Feel free to pull our fork and many thanks for the disposal of your work! :)

Yours,
Holger
